### PR TITLE
add mac command line for opening browser on build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,3 +11,6 @@ To build the documentation:
 ::
 
   make html && firefox build/html/index.html
+
+  on a mac...
+  make html && open -a firefox build/html/index.html


### PR DESCRIPTION
Here goes on the 1st pull request…
Added 'Mac' command line equvilent for opening required browser on building of docs.
