### PR TITLE
Add 'mac' specific command line format (using full path)

### DIFF
--- a/source/salt-cloud-rackspace.rst
+++ b/source/salt-cloud-rackspace.rst
@@ -10,13 +10,14 @@ To create a server called ``web.temp.server`` on Rackspace:
     -p openstack_512 \
     web.temp.server
 
-On the Mac...
+On the Mac we need to use the full path including the username...
+(replacing 'username' and 'path_to_cloud_profiles' respectively)
 
 ::
 
-  sudo ~/.Virtualenvs/create_cloud_server/bin/python \
-    ~/.Virtualenvs/create_cloud_server/bin/salt-cloud \
-    --profiles=/from/secret/wiki/source/sys/misc/salt-cloud/cloud.profiles \
-    --providers-config=/from/secret/wiki/source/sys/misc/salt-cloud/cloud.providers \
+  sudo /Users/username/.Virtualenvs/create_cloud_server/bin/python \
+    /Users/username/.Virtualenvs/create_cloud_server/bin/salt-cloud \
+    --profiles=/Users/username/path_to_cloud_profiles/salt-cloud/cloud.profiles \
+    --providers-config=/Users/username/path_to_cloud_profiles/salt/cloud/cloud.providers \
     --profile=openstack_512 \
     web.temp.server


### PR DESCRIPTION
Full path required for command line format on Mac OS
